### PR TITLE
Implement global ranking calculation per subject

### DIFF
--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -1,36 +1,27 @@
-import React, { useState } from 'react';
+import React from 'react';
 import style from './Summary.module.scss';
-import { useSelectedCountry } from '../../state/selectedCountry';
+import { useActiveCountry } from '../../state/selectedCountry';
 import cn from 'classnames';
-import { usePisaScoreType, setPisaScoreType, PisaScoreType, pisaScoreTypes } from '../../state/pisaScoreType';
+import { setPisaScoreType, usePisaScoreType } from '../../state/pisaScoreType';
 import { fromCamelCaseToUserFormat } from '../../tools/stringsOperators';
-import { CountryDatum } from '../../data/data';
-import { metaData } from '../../data/data';
+import { metaData, PisaScoreType, pisaScoreTypes } from '../../data/data';
 
 export interface SummaryProperties {
     data: { average: number; math: number; reading: number; science: number };
 }
 
 const Summary = ({ data }: SummaryProperties) => {
-    const selectedCountry = useSelectedCountry();
+    const activeCountry = useActiveCountry();
     const selectedType = usePisaScoreType();
-    //const [countryRank, setCountryRank] = useState(); I could not make it work with this hook
-    let countryRank = null;
-
-    if (selectedCountry) {
-        //setCountryRank(ranking.find((country) => country.countryName === selectedCountry.countryName));
-        countryRank = metaData
-            .computeRanking(selectedType)
-            .find((country) => country.countryName === selectedCountry.countryName);
-    }
 
     return (
         <div className={style.summaryCard}>
             <h1>PISA SCORES</h1>
             <p className={style.subtitle}>
-                Latest scores {selectedCountry ? 'for ' + selectedCountry.countryName : 'globally'} <br />
-                {countryRank !== null ? '# ' + countryRank?.ranking + ' out of 81' : null} <br />
-                {selectedCountry ? 'OECD countries in PISA ranking 2022' : null}
+                Latest scores {activeCountry ? 'for ' + activeCountry.countryName : 'globally'} <br />
+                {activeCountry
+                    ? `Ranking #${activeCountry?.ranks[selectedType]} in ${selectedType} out of ${metaData.totalCountries} OECD countries`
+                    : null}
             </p>
             <ul className={style.summaryGrid}>
                 {pisaScoreTypes.map((type) => (

--- a/src/state/pisaScoreType.ts
+++ b/src/state/pisaScoreType.ts
@@ -1,8 +1,5 @@
 import { atom, useAtom } from 'react-atomic-state';
-
-export type PisaScoreType = 'average' | 'science' | 'math' | 'reading';
-
-export const pisaScoreTypes = ['average', 'science', 'math', 'reading'] as const;
+import { PisaScoreType } from '../data/data';
 
 const pisaScoreTypeAtom = atom<PisaScoreType>('average');
 


### PR DESCRIPTION
I implemented a method in metaData that computes the ranking depending on a given string.
I do not know where the best place to locate that functionality is. Also, since it's using the `useSelectedCountry` hook, it's calculating the ranking every time it hovers over a country on the scatterplot (dass no guuud). #help 